### PR TITLE
REMOVE - 불필요해진 “SNS형 팝업 사용 여부” 옵션 제거

### DIFF
--- a/views/pc/products/reviews/_summary.html.erb
+++ b/views/pc/products/reviews/_summary.html.erb
@@ -19,14 +19,8 @@
         <% brand = @brand %>
         <% review_images.each_with_index do |image, index| %>
           <%
-            if brand.review_enable_gallery_popup
-              link_class = 'link-fullscreen-popup fade-from-grayscale'
-              link_data = {url: photo_review_popup_review_path(image.model.id, photo_index: image.mounted_as[5].to_i)}
-            else
-              link_class = 'link-image-zoom fade-from-grayscale'
-              w, h = image.dimension
-              link_data = {url: image.url, width: w, height: h}
-            end
+            link_class = 'link-fullscreen-popup fade-from-grayscale'
+            link_data = {url: photo_review_popup_review_path(image.model.id, photo_index: image.mounted_as[5].to_i)}
           %>
           <li class="photo-review-thumbnail">
             <%= content_tag :a, data: link_data, class: link_class do %>


### PR DESCRIPTION
### 이유
- 모든 쇼핑몰이 true로 설정되어 있고, false로 바꿀 필요가 없음

### 제거 내용
- review_enable_gallery_popup storage 변수 및 사용하는 곳 모두 제거
- .link-image-zoom 관련 내용 제거 (`review_enable_gallery_popup`이 true인 경우에만 사용한다.)
- ImageZoom 관련 내용 제거 (`.link-image-zoom` 이 있을때만 사용한다.)

https://app.asana.com/0/75312375888163/308959848501467